### PR TITLE
Improve file naming

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pygame==1.9.3
 requests==2.19.1
 six==1.11.0
 urllib3==1.23
+hashlib

--- a/speak.py
+++ b/speak.py
@@ -18,6 +18,7 @@ import pygame
 import random
 import sys
 import subprocess
+import hashlib
 
 from gtts import gTTS
 
@@ -28,8 +29,11 @@ def generate_random_string(length):
     return random_string.decode('utf-8')
 
 def get_text_to_speech_file(text, language="es"):
+    h = hashlib.new('sha512')
+    h.update(text)
+    path = h.hexdigest()
     tmp_file_path = '/tmp/{path}-{language}.mp3'.format(
-        path = text, language = language)
+        path = path , language = language)
     if not os.path.isfile(tmp_file_path):
         tts = gTTS(text=text, lang=language)
         tts.save(tmp_file_path)


### PR DESCRIPTION
Use a sha256 of the text instead of the original text to create the sound file, this will fix path traversal problems and now it can use any arbitrary size text